### PR TITLE
Add dynamic theme loader using currenTheme value in data/__config.json

### DIFF
--- a/data/__config.json
+++ b/data/__config.json
@@ -1,1 +1,18 @@
-{}
+{
+  "title": "Dynatic",
+  "description": "",
+  "currentTheme": "Med",
+  "social": [
+    {
+      "type": "twitter",
+      "user": "@jferrettiboke",
+      "link": "https://twitter.com/jferrettiboke"
+    }
+  ],
+  "themes": [
+    {
+      "Med": {},
+      "Hype": {}
+    }
+  ]
+}

--- a/src/shared/components/boot.js
+++ b/src/shared/components/boot.js
@@ -1,3 +1,4 @@
-import Med from './themes/Med/boot.js';
-
-export default Med;
+import config from '../../../data/__config.json';
+var selectedThemeModule = './themes/'+config.currentTheme+'/boot.js';
+const Theme = require(selectedThemeModule);
+export default Theme.default;


### PR DESCRIPTION
2 files have been modified: __config.json just with some config, and boot.js with the dynamic theme loader. Note: import statement (CommonJS) don't allow to load modules using a variable as the route of the module, so i've used require to solve it.
